### PR TITLE
Add option to pass non matching XmlNodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Xtreamer
 
 [![npm version][npm-image]][npm-url]
@@ -115,7 +114,7 @@ xtreamerTransform.on("data", (data) => { });
 
 ### max_xml_size ( default - 10000000 )
 
-`max_xml_size` is maximum the number of characters allowed to hold in memory. 
+`max_xml_size` is maximum the number of characters allowed to hold in memory.
 
 `xtreamer` raises an `error` event in case in memory xml string exceed specified limit. This ensures that the node process doesn't get terminated because of excess in memory data collection.
 
@@ -144,6 +143,34 @@ This function is supposed to accept an xml string as a parameter and should retu
 Note that the converted JSON is internally stringified before sending it back to in data event handler. So it is advised that the transformer function should always return valid JSON object in response.
 
 In case transformer function encounters an error, `xtreamer` emits `error` event and stops the xml conversion process.
+
+## pass_all_nodes (default - false)
+
+`pass_all_nodes` defines whether to pass only matching nodes or all of them.
+
+This can be helpful when modifying an XML document on the fly without loosing non matching nodes.
+
+```javascript
+const xtreamer = require("xtreamer");
+// Override `pass_all_nodes`
+const options = {  pass_all_nodes: true };
+const xtreamer = Xtreamer("XmlNode", options)
+```
+
+The receiving function must verify before processing, i.e.
+```javascript
+// A piped transformer
+async _transform(chunk, enc, done) {
+  if (Buffer.isBuffer(chunk)) chunk = chunk.toString();
+  if (!chunk.startsWith("<XmlNode")) {
+      // Not interesting, just pipe out
+      this.push(chunk);
+  }
+  // Do something with an interesting matching node as usual
+  this.push(chunk + "\n");
+  done();
+}
+```
 
 ## Usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ class Xtreamer extends Transform {
             const xmlNode = this._xmlString.slice(nodeObj.start, endIndex);
 
             if (this._options.pass_all_nodes) {
-               const otherNode = this._xmlString.slice(fromIndex, nodeObj.start - 1).trim();
+               const otherNode = this._xmlString.slice(fromIndex, nodeObj.start).trim();
                fromIndex = endIndex;
                if (otherNode.length > 0) {
                    this.push(otherNode);

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,9 @@ class Xtreamer extends Transform {
     }
 
     _flush(done) {
+        if (this._options.pass_all_nodes) {
+          this.push(this._xmlString.trim());
+        }
         done();
     }
 
@@ -31,10 +34,21 @@ class Xtreamer extends Transform {
         }
         const nodeIndices = getNodeIndices(this._xmlString, this._node);
         let nodes = [];
+        let fromIndex = 0;
+
         for (let index = 0; index < nodeIndices.length; index++) {
             const nodeObj = nodeIndices[index];
             const endIndex = nodeObj.end + this._node.length + 3;
             const xmlNode = this._xmlString.slice(nodeObj.start, endIndex);
+
+            if (this._options.pass_all_nodes) {
+               const otherNode = this._xmlString.slice(fromIndex, nodeObj.start - 1).trim();
+               fromIndex = endIndex;
+               if (otherNode.length > 0) {
+                   this.push(otherNode);
+                   nodes.push(otherNode);
+               }
+            }
             this._options && this._options.transformer && typeof this._options.transformer === "function" ?
                 this.push(JSON.stringify(await this._options.transformer(xmlNode))) :
                 this.push(xmlNode);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xtreamer",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "A NodeJS package to read XML files using NodeJS streams.",
     "main": "lib/index.js",
     "scripts": {


### PR DESCRIPTION
Hi,

This pull request allows to stream non matching nodes.

In my case
`<tu></tu>` nodes are interesting 
`<anyothers />` are not interesting but cannot be dropped.

Final outcome is a modified XML file.

I'm not sure this pull-request is interesting or breaks the spirit of your library. It adds an option to stream the non matching nodes. 

As we're streaming both matches and non matches the receiving stream will need to verify the type before processing or just pass the values along.

I tried to keep your coding standards but felt the if's were not a bad choice, my editor enter some spaces sorry about that.